### PR TITLE
feat: add setup test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ mssTest("another test", ({ db, mongoClient }) => {
 > [!IMPORTANT]
 > You need to install `mongoose` separately.
 
+### Using setup test helper
+
+```js
+// index.test.js
+import { test } from "vitest";
+import { setupMongooseConnection } from "vitest-mms/mongoose/helpers";
+
+// provides default db connection
+// db will be dropped after each test
+// connection will be closed after all tests
+const { connection } = setupMongooseConnection();
+
+test("some test", async () => {
+  // rest of the test
+});
+```
+
 ### Manual Setup (mongoose)
 
 ```js

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     - [Manual Setup](#manual-setup)
     - [Using extended context](#using-extended-context)
   - [Usage with mongoose](#usage-with-mongoose)
+    - [Using setup test helper](#using-setup-test-helper)
     - [Manual Setup (mongoose)](#manual-setup-mongoose)
     - [Using extended context (mongoose)](#using-extended-context-mongoose)
   - [Using ReplSet](#using-replset)

--- a/README.md
+++ b/README.md
@@ -5,16 +5,18 @@
 <!-- prettier-ignore-start -->
 
 <!--toc:start-->
-- [Installation](#installation)
-- [General Usage](#general-usage)
-- [Usage with mongodb](#usage-with-mongodb)
-  - [Manual Setup](#manual-setup)
-  - [Using extended context](#using-extended-context)
-- [Usage with mongoose](#usage-with-mongoose)
-  - [Manual Setup (mongoose)](#manual-setup-mongoose)
-  - [Using extended context (mongoose)](#using-extended-context-mongoose)
-- [Using ReplSet](#using-replset)
-- [Legacy setup files](#legacy-setup-files)
+- [vitest-mms [![NPM Version](https://img.shields.io/npm/v/vitest-mms)](https://www.npmjs.com/package/vitest-mms)](#vitest-mms-npm-versionhttpsimgshieldsionpmvvitest-mmshttpswwwnpmjscompackagevitest-mms)
+  - [Installation](#installation)
+  - [General Usage](#general-usage)
+  - [Usage with mongodb](#usage-with-mongodb)
+    - [Using setup test helper](#using-setup-test-helper)
+    - [Manual Setup](#manual-setup)
+    - [Using extended context](#using-extended-context)
+  - [Usage with mongoose](#usage-with-mongoose)
+    - [Manual Setup (mongoose)](#manual-setup-mongoose)
+    - [Using extended context (mongoose)](#using-extended-context-mongoose)
+  - [Using ReplSet](#using-replset)
+  - [Legacy setup files](#legacy-setup-files)
 <!--toc:end-->
 
 <!-- prettier-ignore-end -->
@@ -64,6 +66,21 @@ test("some test", () => {
 
 > [!IMPORTANT]
 > You need to install `mongodb` separately.
+
+### Using setup test helper
+
+```js
+// index.test.js
+import { setupDb } from "vitest-mms/mongodb/helpers";
+
+// db is cleared after each test
+// mongoClient is disconnected after all tests are done
+const { db, mongoClient } = setupDb();
+
+test("some test", async () => {
+  // rest of the test
+});
+```
 
 ### Manual Setup
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
       "require": "./dist/mongodb/mmsTest.cjs",
       "import": "./dist/mongodb/mmsTest.mjs"
     },
+    "./mongodb/helpers": {
+      "types": "./dist/mongodb/helpers.d.ts",
+      "require": "./dist/mongodb/helpers.cjs",
+      "import": "./dist/mongodb/helpers.mjs"
+    },
     "./mongoose/setupFile": {
       "types": "./dist/mongoose/setupFile.d.ts",
       "require": "./dist/mongoose/setupFile.cjs",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
       "types": "./dist/mongoose/mmsTest.d.ts",
       "require": "./dist/mongoose/mmsTest.cjs",
       "import": "./dist/mongoose/mmsTest.mjs"
+    },
+    "./mongoose/helpers": {
+      "types": "./dist/mongoose/helpers.d.ts",
+      "require": "./dist/mongoose/helpers.cjs",
+      "import": "./dist/mongoose/helpers.mjs"
     }
   },
   "author": "Daniel Perez Alvarez (http://github.com/danielpza)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,27 @@ importers:
         specifier: link:../..
         version: link:../..
 
+  tests/mongoose-test-helper:
+    devDependencies:
+      '@tsconfig/node-lts':
+        specifier: ^22.0.2
+        version: 22.0.2
+      mongodb-memory-server:
+        specifier: ^10.1.4
+        version: 10.1.4
+      mongoose:
+        specifier: ^8.16.0
+        version: 8.16.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.0.4)
+      vitest-mms:
+        specifier: link:../..
+        version: link:../..
+
 packages:
 
   '@esbuild/aix-ppc64@0.21.5':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,27 @@ importers:
         specifier: link:../..
         version: link:../..
 
+  tests/mongodb-test-helper:
+    devDependencies:
+      '@tsconfig/node-lts':
+        specifier: ^22.0.2
+        version: 22.0.2
+      mongodb:
+        specifier: ^6.17.0
+        version: 6.17.0
+      mongodb-memory-server:
+        specifier: ^10.1.4
+        version: 10.1.4
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.0.4)
+      vitest-mms:
+        specifier: link:../..
+        version: link:../..
+
   tests/mongoose-extended-test:
     devDependencies:
       '@tsconfig/node-lts':

--- a/src/mongodb/helpers.ts
+++ b/src/mongodb/helpers.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from "node:crypto";
+
+import { MongoClient } from "mongodb";
+import { afterEach, beforeAll, inject } from "vitest";
+
+export function setupDb() {
+  const uri = inject("MONGO_URI");
+
+  const mongoClient = new MongoClient(uri);
+  const db = mongoClient.db(randomUUID());
+
+  beforeAll(async () => {
+    await mongoClient.connect();
+
+    return async () => {
+      await mongoClient.close();
+    };
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+  });
+
+  return { mongoClient, db };
+}

--- a/src/mongoose/helpers.ts
+++ b/src/mongoose/helpers.ts
@@ -1,0 +1,24 @@
+import { randomUUID } from "node:crypto";
+
+import { afterEach, beforeAll, inject } from "vitest";
+import { createConnection } from "mongoose";
+
+export function setupMongooseConnection() {
+  const uri = inject("MONGO_URI");
+
+  const connection = createConnection(uri).useDb(randomUUID());
+
+  beforeAll(async () => {
+    await connection.asPromise();
+
+    return async () => {
+      await connection.close();
+    };
+  });
+
+  afterEach(async () => {
+    await connection.dropDatabase();
+  });
+
+  return { connection };
+}

--- a/tests/mongodb-test-helper/package.json
+++ b/tests/mongodb-test-helper/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mongodb-test-helper",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@tsconfig/node-lts": "^22.0.2",
+    "mongodb": "^6.17.0",
+    "mongodb-memory-server": "^10.1.4",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4",
+    "vitest-mms": "link:../.."
+  }
+}

--- a/tests/mongodb-test-helper/src/index.test.ts
+++ b/tests/mongodb-test-helper/src/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { setupDb } from "vitest-mms/mongodb/helpers";
+
+import { insertUser } from "./index.js";
+
+const { mongoClient, db } = setupDb();
+
+test("setupDb", async () => {
+  expect(mongoClient).toBeDefined();
+  expect(db).toBeDefined();
+});
+
+test("check dbs are unique1", async () => {
+  await insertUser(db);
+  await insertUser(db);
+  expect(await db.collection("users").countDocuments()).toBe(2);
+});
+
+test("check dbs are unique2", async () => {
+  await insertUser(db);
+  expect(await db.collection("users").countDocuments()).toBe(1);
+});
+
+// describe("performance", () => {
+//   for (let i = 0; i < 1000; i++) {
+//     test(`test ${i}`, async () => {
+//       expect(true).toBe(true);
+//     });
+//   }
+// });

--- a/tests/mongodb-test-helper/src/index.test.ts
+++ b/tests/mongodb-test-helper/src/index.test.ts
@@ -21,10 +21,10 @@ test("check dbs are unique2", async () => {
   expect(await db.collection("users").countDocuments()).toBe(1);
 });
 
-// describe("performance", () => {
-//   for (let i = 0; i < 1000; i++) {
-//     test(`test ${i}`, async () => {
-//       expect(true).toBe(true);
-//     });
-//   }
-// });
+describe("performance", () => {
+  for (let i = 0; i < 1000; i++) {
+    test(`test ${i}`, async () => {
+      expect(true).toBe(true);
+    });
+  }
+});

--- a/tests/mongodb-test-helper/src/index.ts
+++ b/tests/mongodb-test-helper/src/index.ts
@@ -1,0 +1,5 @@
+import { Db } from "mongodb";
+
+export async function insertUser(db: Db) {
+  await db.collection("users").insertOne({ name: "John" });
+}

--- a/tests/mongodb-test-helper/tsconfig.json
+++ b/tests/mongodb-test-helper/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@tsconfig/node-lts",
+  "compilerOptions": {
+    "types": ["vitest-mms/globalSetup"]
+  }
+}

--- a/tests/mongodb-test-helper/vitest.config.js
+++ b/tests/mongodb-test-helper/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globalSetup: ["vitest-mms/globalSetup"],
+  },
+});

--- a/tests/mongoose-test-helper/package.json
+++ b/tests/mongoose-test-helper/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mongoose-setup-file",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@tsconfig/node-lts": "^22.0.2",
+    "mongodb-memory-server": "^10.1.4",
+    "mongoose": "^8.16.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4",
+    "vitest-mms": "link:../.."
+  }
+}

--- a/tests/mongoose-test-helper/package.json
+++ b/tests/mongoose-test-helper/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mongoose-setup-file",
+  "name": "mongoose-test-helper",
   "type": "module",
   "scripts": {
     "test": "vitest run"

--- a/tests/mongoose-test-helper/src/index.test.ts
+++ b/tests/mongoose-test-helper/src/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { insertUser } from "./index.js";
+import { Schema } from "mongoose";
+import { setupMongooseConnection } from "vitest-mms/mongoose/helpers";
+
+const { connection } = setupMongooseConnection();
+
+test("setupDb", async () => {
+  expect(connection).toBeDefined();
+});
+
+test("check dbs are unique1", async () => {
+  await insertUser(connection);
+  await insertUser(connection);
+  expect(await connection.db!.collection("users").countDocuments()).toBe(2);
+});
+
+test("check dbs are unique2", async () => {
+  await insertUser(connection);
+  expect(await connection.db!.collection("users").countDocuments()).toBe(1);
+});
+
+test("using mongoose schema", async () => {
+  const Users = connection.model("User", new Schema({ name: String }));
+  await Users.create({ name: "John" });
+  expect(await Users.countDocuments()).toBe(1);
+});
+
+describe("performance", () => {
+  for (let i = 0; i < 1000; i++)
+    test(`test ${i}`, async () => {
+      expect(true).toBe(true);
+    });
+});

--- a/tests/mongoose-test-helper/src/index.ts
+++ b/tests/mongoose-test-helper/src/index.ts
@@ -1,0 +1,5 @@
+import { Connection } from "mongoose";
+
+export async function insertUser(connection: Connection) {
+  await connection.db!.collection("users").insertOne({ name: "John" });
+}

--- a/tests/mongoose-test-helper/tsconfig.json
+++ b/tests/mongoose-test-helper/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/node-lts"
+}

--- a/tests/mongoose-test-helper/vitest.config.js
+++ b/tests/mongoose-test-helper/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globalSetup: ["vitest-mms/globalSetup"],
+  },
+});


### PR DESCRIPTION
Added `setupDb` and `setupMongooseConnection` helpers. These are alternatives to extending the test context with `mmsTest` and the legacy setup files